### PR TITLE
Add app_id window attribute support

### DIFF
--- a/src/hyprkan.py
+++ b/src/hyprkan.py
@@ -630,7 +630,7 @@ class Sway(WMBaseListener):
         if not focused:
             return {"cls": "*", "title": "*"}
         return {
-            "cls": focused.window_class or "*",
+            "cls": focused.app_id or focused.window_class or "*",
             "title": focused.name or "*",  # type: ignore
         }
 


### PR DESCRIPTION
Currently, wayland-only windows are limited in detection capabilities because they have the app_id attribute, rather than the class attribute; in the implementations of almost all window managers in hyprkan, app_id is ignored and only the class attribute is selected. The one exception is Niri, where class is ignored and only the app_id attribute is selected - this has the opposite effect, where xwayland windows are restricted (due to using class instead of app_id).

This pull request adds the app_id field, which can be set in the configuration alongside class. It compares against the app_id field in all Wayland window managers (and the field is automatically blank for windows in X11). The class field in the configuration now matches against the class attribute of windows in Niri.